### PR TITLE
Fix for issue #11

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -85,11 +85,13 @@ var SparqlClient = module.exports = function (endpoint, options) {
             var requestBody = _.extend(defaultParameters, {
                 query: query
             });
+            delete defaultParameters.update;
         }
         else {
             var requestBody = _.extend(defaultParameters, {
                 update: query
             });
+            delete defaultParameters.query;
         }
 
         var opts = {


### PR DESCRIPTION
Issue: https://github.com/thomasfr/node-sparql-client/issues/11
Description: Remove _query_ or _update_ form the parameters which might be left from the previous request.
