### PR TITLE
Added functionality for SPARQL INSERT

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -81,7 +81,7 @@ var SparqlClient = module.exports = function (endpoint, options) {
     };
 
     var sparqlRequest = function sparqlRequest(query, callback) {
-        if (query.indexOf("INSERT DATA") == -1 && query.indexOf("DELETE") == -1) {
+        if (query.indexOf("INSERT DATA") == -1 && query.indexOf("DELETE") == -1 && query.indexOf("INSERT") == -1) {
             var requestBody = _.extend(defaultParameters, {
                 query: query
             });


### PR DESCRIPTION
The current sparql-client lacks functionality for queries such as:

```
INSERT {
  ?s ?p ?o.
} WHERE {
  ?s ?p ?o
} ;
```

I only added another condition to check if the query is an "INSERT" query to the existing "INSERT DATA" and "DELETE" conditions.

Jeremy